### PR TITLE
Fix Kotlin plugin versions

### DIFF
--- a/Lab4_Moviles/app/build.gradle.kts
+++ b/Lab4_Moviles/app/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
-    alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlin.compose)
-    alias(libs.plugins.kotlin.kapt)
+    id("com.android.application")
+    kotlin("android")
+    kotlin("kapt")
+    kotlin("plugin.compose")
 }
 
 android {

--- a/Lab4_Moviles/build.gradle.kts
+++ b/Lab4_Moviles/build.gradle.kts
@@ -1,6 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+buildscript {
+    extra["kotlinVersion"] = "2.0.0"
+    dependencies {
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${extra["kotlinVersion"]}")
+    }
+}
+
 plugins {
-    alias(libs.plugins.android.application) apply false
-    alias(libs.plugins.kotlin.android) apply false
-    alias(libs.plugins.kotlin.compose) apply false
+    id("com.android.application") apply false
+    kotlin("android") apply false
+    kotlin("plugin.compose") apply false
 }


### PR DESCRIPTION
## Summary
- avoid specifying Kotlin plugin versions in the app module
- configure Kotlin plugin version once in the root build file

## Testing
- `./gradlew tasks --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684a1843535c832fb792822c27dfc9c9