### PR TITLE
Fix Kotlin version configuration

### DIFF
--- a/Lab4_Moviles/app/build.gradle.kts
+++ b/Lab4_Moviles/app/build.gradle.kts
@@ -2,7 +2,6 @@ plugins {
     id("com.android.application")
     kotlin("android")
     kotlin("kapt")
-    kotlin("plugin.compose")
 }
 
 android {

--- a/Lab4_Moviles/build.gradle.kts
+++ b/Lab4_Moviles/build.gradle.kts
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    extra["kotlinVersion"] = "2.0.0"
+    extra["kotlinVersion"] = "1.8.20"
     dependencies {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${extra["kotlinVersion"]}")
     }
@@ -9,5 +9,5 @@ buildscript {
 plugins {
     id("com.android.application") apply false
     kotlin("android") apply false
-    kotlin("plugin.compose") apply false
+    kotlin("kapt") apply false
 }


### PR DESCRIPTION
## Summary
- set `kotlinVersion` globally in root build.gradle
- use only `kotlin("android")` and `kotlin("kapt")` in the app module

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684a19db9f34832f9c655eb3a943fe5d